### PR TITLE
Broaden regression coverage and add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Run Tests
+
+on:
+  push:
+    branches: ["main", "work", "**"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest --cov=hurricane_spy --cov-report=xml
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Hurricane_V2
+
+This repository hosts the Hurricane SPY automation codebase. The detailed
+architecture, setup instructions, and usage guide are documented in
+[`docs/hurricane_spy_automation.md`](docs/hurricane_spy_automation.md).
+
+If merge conflicts arise around this README, prefer keeping the project title
+above and append any additional notes below rather than rewriting the header.

--- a/docs/hurricane_spy_automation.md
+++ b/docs/hurricane_spy_automation.md
@@ -1,0 +1,113 @@
+# Hurricane SPY Automated Pipeline
+
+This repository implements the **Hurricane SPY** multi-timeframe market prediction framework described in the accompanying research note. The code provides an end-to-end automation layer that transforms market microstructure inputs into probabilistic support/resistance maps, directional calls with abstention logic, and speed forecasts.
+
+## Project Layout
+
+```
+hurricane_spy/
+├── __init__.py
+├── aggregation.py
+├── config.py
+├── data_structures.py
+├── execution.py
+├── diagnostics.py
+├── features.py
+├── gating.py
+├── pipeline.py
+└── scripts/
+    ├── run_pipeline.py
+    └── run_trading.py
+```
+
+## Getting Started
+
+1. Install dependencies (requires Python 3.9+):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Populate the data bundle expected by the pipeline (see
+   `hurricane_spy/data_structures.py` for schema details).
+3. Run the example pipeline:
+   ```bash
+   python -m hurricane_spy.scripts.run_pipeline
+   ```
+
+## Algorithm Overview
+
+The implementation follows the structure of the Hurricane SPY specification:
+
+- **Feature Construction** (`features.py`)
+  - Hurricane intensity scale derived from realized volatility, drift, and gamma
+    pressure.
+  - Kernel-based support/resistance potential maps.
+  - Directional drift estimator combining GEX sign, dark-pool index changes,
+    technical alignment, and order-flow imbalance.
+  - Speed forecasts that scale the local volatility surface with variance
+    amplifiers.
+  - Barrier hitting and conformal modules for probability calibration.
+
+- **Stability Gating** (`gating.py`)
+  - Event-aware abstention with configurable cooling windows.
+  - Regime flip detection using a rolling CUSUM statistic and volatility regime
+    classifier.
+  - Exogenous flow dominance and hedging-pressure gating to suppress unreliable
+    signals.
+
+- **Aggregation** (`aggregation.py`)
+  - Stress-weighted global minimum-variance (GMV) blending across timeframes.
+  - Conformalized reliability adjustment and Brier score tracking per regime.
+
+- **Pipeline Orchestration** (`pipeline.py`)
+  - Validates inputs, computes per-timeframe forecasts, applies stability
+    controls, and aggregates the final predictions.
+  - Provides detailed diagnostics of calibration, gating decisions, and
+    abstention rationale.
+
+- **Trading Integration** (`execution.py`)
+  - Lightweight Alpaca REST client with environment-loaded credentials.
+  - Risk controls for mapping aggregate forecasts into target positions.
+  - Trader orchestration that queries current positions, derives the
+    rebalance required, and routes orders (including optional flatten-on-abstain).
+
+- **Data Source Bridges** (`data_sources.py`)
+  - Convenience client for the Unusual Whales API with helpers to align order
+    flow, dark pool prints, and gamma exposure streams.
+  - Utilities for merging those feeds into the order-flow imbalance frame and
+    assembling validated `MarketDataBundle` objects for the pipeline.
+
+## Sending Orders to Alpaca
+
+The repository ships with a reference adapter that transforms Hurricane SPY
+forecasts into Alpaca orders. To use it:
+
+1. Export your Alpaca credentials (paper or live) as environment variables:
+   ```bash
+   export ALPACA_API_KEY="<your key>"
+   export ALPACA_SECRET_KEY="<your secret>"
+   # Optional override if not using the default paper endpoint
+   export ALPACA_BASE_URL="https://paper-api.alpaca.markets"
+   ```
+2. Adjust the trading configuration (symbol, sizing, risk thresholds) either by
+   editing `hurricane_spy/scripts/run_trading.py` or by instantiating
+   `TradingConfig` in your own harness.
+3. (Optional) Export your Unusual Whales API token to drive real-time order
+   flow ingestion:
+   ```bash
+   export UNUSUAL_WHALES_API_TOKEN="<your token>"
+   ```
+4. Run the demonstration script to see the end-to-end automation, including the
+   trade decision, any submitted order payloads, and the data ingestion mode
+   (synthetic vs. live Unusual Whales feeds):
+   ```bash
+   python -m hurricane_spy.scripts.run_trading
+   ```
+
+The `HurricaneTrader` class can also be embedded into schedulers or other
+automation frameworks. When the `UNUSUAL_WHALES_API_TOKEN` environment variable
+is provided, the reference trading harness will automatically pull order-flow
+and dark-pool data from the Unusual Whales API; otherwise it falls back to the
+synthetic bundle generator for offline testing.
+
+See the inline documentation throughout the codebase for the precise formulas
+and configuration options.

--- a/hurricane_spy/__init__.py
+++ b/hurricane_spy/__init__.py
@@ -1,0 +1,30 @@
+"""Top-level package for the Hurricane SPY automated prediction system."""
+
+from .config import HurricaneConfig, TimeframeConfig
+from .execution import (
+    AlpacaClient,
+    AlpacaCredentials,
+    HurricaneTrader,
+    TradeDecision,
+    TradingConfig,
+)
+from .data_sources import (
+    UnusualWhalesClient,
+    assemble_bundle,
+    merge_unusual_whales_signals,
+)
+from .pipeline import HurricaneSPY
+
+__all__ = [
+    "HurricaneConfig",
+    "TimeframeConfig",
+    "HurricaneSPY",
+    "AlpacaCredentials",
+    "AlpacaClient",
+    "TradingConfig",
+    "TradeDecision",
+    "HurricaneTrader",
+    "UnusualWhalesClient",
+    "merge_unusual_whales_signals",
+    "assemble_bundle",
+]

--- a/hurricane_spy/aggregation.py
+++ b/hurricane_spy/aggregation.py
@@ -1,0 +1,53 @@
+"""Aggregation utilities for Hurricane SPY."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class StressWeightedGMV:
+    """Stress-weighted Global Minimum Variance aggregator."""
+
+    tikhonov: float
+    stress_weight: float
+
+    def __call__(
+        self,
+        forecasts: Mapping[str, Mapping[str, float]],
+        covariance: pd.DataFrame,
+        stress_level: float,
+    ) -> Dict[str, object]:
+        if covariance.empty:
+            raise ValueError("Covariance matrix must not be empty")
+        cov = covariance.copy()
+        cov.values[np.diag_indices_from(cov.values)] += self.tikhonov
+        inv_cov = np.linalg.pinv(cov.values)
+        ones = np.ones(len(cov))
+        weights = inv_cov @ ones / (ones.T @ inv_cov @ ones)
+        # Apply stress weighting: increase emphasis on slower horizons when stress high
+        stress_multiplier = 1 + self.stress_weight * max(stress_level, 0)
+        stress_adjusted = weights / np.sum(weights)
+        stress_adjusted[-1] *= stress_multiplier
+        stress_adjusted /= np.sum(stress_adjusted)
+        weights = {name: float(stress_adjusted[i]) for i, name in enumerate(cov.index)}
+
+        aggregated: Dict[str, Any] = {"weights": weights}
+        keys_to_aggregate = (
+            "support_resistance",
+            "direction_score",
+            "speed",
+            "probability",
+            "hurricane_intensity",
+        )
+        for key in keys_to_aggregate:
+            if all(key in forecasts[name] for name in cov.index):
+                aggregated[key] = float(
+                    sum(stress_adjusted[i] * forecasts[name][key] for i, name in enumerate(cov.index))
+                )
+
+        return aggregated

--- a/hurricane_spy/config.py
+++ b/hurricane_spy/config.py
@@ -1,0 +1,64 @@
+"""Configuration objects for the Hurricane SPY pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping, Sequence
+
+
+@dataclass
+class TimeframeConfig:
+    r"""Configuration for a single timeframe.
+
+    Attributes
+    ----------
+    name:
+        Human readable identifier of the timeframe (e.g. ``"1m"``).
+    horizon_minutes:
+        Forecast horizon expressed in minutes. Used for volatility scaling and
+        horizon-aware modules such as finite-horizon barrier probabilities.
+    abstention_threshold:
+        Margin around 0.5 probability inside which the model abstains. The value
+        corresponds to the ``\\delta`` term in the specification.
+    lambda_level:
+        Kernel half-width controlling the support/resistance potential.
+    weights:
+        Dictionary with entries ``gamma``, ``dark_pool`` and ``volume`` that
+        weight the respective components of the level score ``S(L)``.
+    speed_coefficients:
+        Tuple ``(alpha_v, beta_v, chi_v)`` for the speed forecast amplifier.
+    direction_threshold:
+        Magnitude of the drift estimate above which the sign is emitted instead
+        of abstaining.
+    """
+
+    name: str
+    horizon_minutes: int
+    abstention_threshold: float = 0.05
+    lambda_level: float = 1.0
+    weights: Mapping[str, float] = field(
+        default_factory=lambda: {"gamma": 0.4, "dark_pool": 0.3, "volume": 0.3}
+    )
+    speed_coefficients: Sequence[float] = (0.25, 0.1, 0.05)
+    direction_threshold: float = 0.0
+
+
+@dataclass
+class HurricaneConfig:
+    """Configuration for the Hurricane SPY pipeline."""
+
+    timeframes: Iterable[TimeframeConfig]
+    hurricane_alpha: float = 0.6
+    hurricane_beta: float = 0.4
+    stress_weight: float = 0.35
+    cusum_threshold: float = 3.0
+    cusum_drift: float = 0.2
+    hedging_pressure_limit: float = 0.7
+    exogenous_flow_limit: float = 0.65
+    cooling_window: int = 5
+    gmvtikhonov: float = 1e-3
+
+    def timeframe_by_name(self) -> Dict[str, TimeframeConfig]:
+        """Return the timeframe configuration indexed by name."""
+
+        return {tf.name: tf for tf in self.timeframes}

--- a/hurricane_spy/data_sources.py
+++ b/hurricane_spy/data_sources.py
@@ -1,0 +1,220 @@
+"""External data source integrations for Hurricane SPY."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency for offline test environments
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover - handled gracefully in client methods
+    requests = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - type checkers see the real interface
+    import requests as _requests_type
+else:  # pragma: no cover - runtime placeholder to keep type checkers satisfied
+    from typing import Any as _requests_type  # type: ignore
+
+from .data_structures import MarketDataBundle
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_dataframe(payload: Mapping[str, Any], key: str) -> pd.DataFrame:
+    """Normalise API payloads into dataframes.
+
+    The Unusual Whales REST responses typically wrap the useful rows inside a
+    ``data`` field. We coerce that into a ``DataFrame`` while keeping any
+    metadata available via the ``meta`` field.
+    """
+
+    rows = payload.get(key, [])
+    if isinstance(rows, list):
+        return pd.DataFrame(rows)
+    if isinstance(rows, MutableMapping):
+        return pd.DataFrame([rows])
+    raise ValueError(f"Unexpected payload structure for key '{key}': {type(rows)!r}")
+
+
+@dataclass
+class UnusualWhalesClient:
+    """Minimal Unusual Whales REST client.
+
+    Only a subset of endpoints is implemented, but the class keeps the
+    authentication, pagination handling, and retry logic in one place so the
+    pipeline can request order-flow and dark-pool data without duplicating
+    boilerplate.
+    """
+
+    api_token: str
+    base_url: str = "https://phx.unusualwhales.com/api"
+    session: Optional["_requests_type.Session"] = None
+    timeout: float = 10.0
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
+        if requests is None:  # pragma: no cover - exercised in tests without dependency
+            raise RuntimeError(
+                "The 'requests' package is required to fetch Unusual Whales data. "
+                "Install the optional dependency with `pip install requests`."
+            )
+        url = f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+        headers = {"Authorization": f"Bearer {self.api_token}"}
+        sess = self.session or requests.Session()
+        try:
+            response = sess.request(method, url, params=params, headers=headers, timeout=self.timeout)
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            LOGGER.error("Unusual Whales request failed: %s", exc, exc_info=True)
+            raise
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            LOGGER.error("Unusual Whales connectivity issue: %s", exc, exc_info=True)
+            raise
+        return response.json()
+
+    def fetch_options_flow(
+        self,
+        symbol: str,
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        limit: int = 500,
+    ) -> pd.DataFrame:
+        params: Dict[str, Any] = {"ticker": symbol.upper(), "limit": limit}
+        if start is not None:
+            params["start"] = start.astimezone(UTC).isoformat()
+        if end is not None:
+            params["end"] = end.astimezone(UTC).isoformat()
+        payload = self._request("GET", "/whales/options/flow", params=params)
+        return _ensure_dataframe(payload, "data")
+
+    def fetch_dark_pool_activity(
+        self,
+        symbol: str,
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+    ) -> pd.DataFrame:
+        params: Dict[str, Any] = {"ticker": symbol.upper()}
+        if start is not None:
+            params["start"] = start.astimezone(UTC).isoformat()
+        if end is not None:
+            params["end"] = end.astimezone(UTC).isoformat()
+        payload = self._request("GET", "/darkpool/volume", params=params)
+        return _ensure_dataframe(payload, "data")
+
+    def fetch_gamma_exposure(
+        self,
+        symbol: str,
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+    ) -> pd.DataFrame:
+        params: Dict[str, Any] = {"ticker": symbol.upper()}
+        if start is not None:
+            params["start"] = start.astimezone(UTC).isoformat()
+        if end is not None:
+            params["end"] = end.astimezone(UTC).isoformat()
+        payload = self._request("GET", "/options/gex", params=params)
+        return _ensure_dataframe(payload, "data")
+
+
+def merge_unusual_whales_signals(
+    *,
+    flow: pd.DataFrame,
+    dark_pool: pd.DataFrame,
+    gex: pd.DataFrame,
+    resample_rule: str = "1min",
+) -> pd.DataFrame:
+    """Merge Unusual Whales streams into the OFI frame expected by the pipeline."""
+
+    frames = []
+    if not flow.empty:
+        flow_frame = flow.copy()
+        if "timestamp" in flow_frame:
+            flow_frame["timestamp"] = pd.to_datetime(flow_frame["timestamp"], utc=True)
+            flow_frame = flow_frame.set_index("timestamp")
+        frames.append(flow_frame.resample(resample_rule).sum(min_count=1))
+    if not dark_pool.empty:
+        pool = dark_pool.copy()
+        if "timestamp" in pool:
+            pool["timestamp"] = pd.to_datetime(pool["timestamp"], utc=True)
+            pool = pool.set_index("timestamp")
+        frames.append(pool.resample(resample_rule).sum(min_count=1))
+    if not gex.empty:
+        gex_frame = gex.copy()
+        if "timestamp" in gex_frame:
+            gex_frame["timestamp"] = pd.to_datetime(gex_frame["timestamp"], utc=True)
+            gex_frame = gex_frame.set_index("timestamp")
+        frames.append(gex_frame.resample(resample_rule).mean())
+
+    if not frames:
+        raise ValueError("At least one Unusual Whales dataframe must be non-empty")
+
+    combined = pd.concat(frames, axis=1)
+    if "ofi" not in combined:
+        combined["ofi"] = combined.get("net_flow", combined.sum(axis=1)).fillna(0.0)
+    if "dark_pool_index" not in combined and "darkpool_net" in combined:
+        combined["dark_pool_index"] = combined["darkpool_net"].cumsum().fillna(0.0)
+    if "exogenous_flow" not in combined:
+        combined["exogenous_flow"] = combined.get("lit_volume", 0.0)
+    if "variance_amplifier" not in combined:
+        combined["variance_amplifier"] = (
+            combined["ofi"].abs() / combined["ofi"].abs().rolling(50).mean()
+        ).clip(lower=0.0).fillna(0.0)
+    return combined.fillna(method="ffill").fillna(0.0)
+
+
+def assemble_bundle(
+    *,
+    price: pd.DataFrame,
+    greeks: pd.DataFrame,
+    ofi: pd.DataFrame,
+    technical: Mapping[str, pd.Series],
+    levels: pd.DataFrame,
+    realised_vol: Mapping[str, pd.Series],
+    base_vol: Mapping[str, float],
+    barrier_levels: Optional[Mapping[str, Mapping[str, float]]] = None,
+    events: Optional[pd.DataFrame] = None,
+    stress_index: Optional[pd.Series] = None,
+) -> MarketDataBundle:
+    """Convenience helper to construct a validated ``MarketDataBundle``."""
+
+    bundle = MarketDataBundle(
+        price=price,
+        greeks=greeks,
+        ofi=ofi,
+        technical=technical,
+        levels=levels,
+        realised_vol=realised_vol,
+        base_vol=base_vol,
+        barrier_levels=barrier_levels,
+        events=events,
+        stress_index=stress_index,
+    )
+    bundle.validate(timeframes=technical.keys())
+    return bundle
+
+
+def align_series(series: Iterable[pd.Series], rule: str = "1min") -> pd.DatetimeIndex:
+    """Create a shared datetime index for multiple series."""
+
+    union = pd.Index([])
+    for s in series:
+        idx = pd.DatetimeIndex(s.index)
+        if idx.tz is None:
+            idx = idx.tz_localize(UTC)
+        union = union.union(idx)
+    if union.empty:
+        raise ValueError("At least one series is required to build an index")
+    return union.sort_values().unique().tz_convert(UTC).floor(rule)
+

--- a/hurricane_spy/data_structures.py
+++ b/hurricane_spy/data_structures.py
@@ -1,0 +1,104 @@
+"""Data structures used by the Hurricane SPY pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class MarketDataBundle:
+    r"""Container holding the data required for running the pipeline.
+
+    Attributes
+    ----------
+    price:
+        OHLCV data indexed by timestamp with columns ``[open, high, low, close,
+        volume]``.
+    greeks:
+        Options metrics indexed by timestamp with columns ``[gamma, vanna, charm]``.
+    ofi:
+        Order-flow imbalance data indexed by timestamp with at least an
+        ``ofi`` column and optionally ``dark_pool_index`` and ``exogenous_flow``.
+    technical:
+        Technical alignment signals per timeframe. Expected format is a mapping
+        from timeframe name to a time-indexed series of alignment scores in
+        ``[-1, 1]``.
+    levels:
+        Support/resistance candidate levels indexed by timestamp with columns
+        ``[level, gamma_score, dark_pool_score, volume_score]``.
+    realised_vol:
+        Realised volatility estimates per timeframe. Mapping from timeframe name
+        to series of non-negative floats.
+    base_vol:
+        Baseline volatility estimates (``\\sigma_{0,T}``) per timeframe.
+    barrier_levels:
+        Optional mapping from timeframe name to dictionaries containing
+        ``upper`` and ``lower`` barrier levels for barrier hitting probability
+        calculations.
+    events:
+        Optional time-indexed frame with binary columns ``[is_event]`` indicating
+        market events that trigger abstention.
+    stress_index:
+        Optional series representing the macro stress level used for
+        stress-weighted aggregation.
+    """
+
+    price: pd.DataFrame
+    greeks: pd.DataFrame
+    ofi: pd.DataFrame
+    technical: Mapping[str, pd.Series]
+    levels: pd.DataFrame
+    realised_vol: Mapping[str, pd.Series]
+    base_vol: Mapping[str, float]
+    barrier_levels: Optional[Mapping[str, Mapping[str, float]]] = None
+    events: Optional[pd.DataFrame] = None
+    stress_index: Optional[pd.Series] = None
+
+    def latest(self) -> Dict[str, pd.Series]:
+        """Return the latest observation for each dataframe-like input."""
+
+        latest_data = {
+            "price": self.price.iloc[-1],
+            "greeks": self.greeks.iloc[-1],
+            "ofi": self.ofi.iloc[-1],
+            "levels": self.levels[self.levels.index == self.levels.index.max()],
+        }
+        if self.events is not None:
+            latest_data["events"] = self.events.iloc[-1]
+        if self.stress_index is not None:
+            latest_data["stress"] = self.stress_index.iloc[-1]
+        return latest_data
+
+    def validate(self, timeframes: Iterable[str]) -> None:
+        """Validate that the bundle contains the expected inputs."""
+
+        required_price_cols = {"open", "high", "low", "close", "volume"}
+        required_greeks_cols = {"gamma", "vanna", "charm"}
+        required_levels_cols = {
+            "level",
+            "gamma_score",
+            "dark_pool_score",
+            "volume_score",
+        }
+        if not required_price_cols.issubset(self.price.columns):
+            missing = required_price_cols - set(self.price.columns)
+            raise ValueError(f"Missing price columns: {missing}")
+        if not required_greeks_cols.issubset(self.greeks.columns):
+            missing = required_greeks_cols - set(self.greeks.columns)
+            raise ValueError(f"Missing greek columns: {missing}")
+        if not required_levels_cols.issubset(self.levels.columns):
+            missing = required_levels_cols - set(self.levels.columns)
+            raise ValueError(f"Missing level columns: {missing}")
+        if "ofi" not in self.ofi.columns:
+            raise ValueError("Order-flow imbalance data must include an 'ofi' column")
+        for tf in timeframes:
+            if tf not in self.realised_vol:
+                raise ValueError(f"Realised volatility missing for timeframe {tf}")
+            if tf not in self.base_vol:
+                raise ValueError(f"Base volatility missing for timeframe {tf}")
+            if np.any(self.realised_vol[tf] < 0):
+                raise ValueError(f"Realised volatility contains negatives for {tf}")

--- a/hurricane_spy/diagnostics.py
+++ b/hurricane_spy/diagnostics.py
@@ -1,0 +1,45 @@
+"""Diagnostics and logging utilities for Hurricane SPY."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping
+
+import numpy as np
+import pandas as pd
+
+from .features import brier_score
+
+
+@dataclass
+class ReliabilityTracker:
+    """Track calibration and reliability statistics by regime."""
+
+    regimes: List[str] = field(default_factory=lambda: ["calm", "trend", "storm", "pin"])
+    records: Dict[str, List[float]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.records = {regime: [] for regime in self.regimes}
+
+    def update(self, regime: str, probability: float, outcome: float) -> None:
+        if regime not in self.records:
+            self.records[regime] = []
+        self.records[regime].append(brier_score(probability, outcome))
+
+    def summary(self) -> pd.Series:
+        return pd.Series({regime: np.mean(values) if values else np.nan for regime, values in self.records.items()})
+
+
+@dataclass
+class GatingDiagnostics:
+    entries: List[Dict[str, float]] = field(default_factory=list)
+
+    def log(self, timestamp, gates: Mapping[str, float]) -> None:
+        record = {"timestamp": timestamp}
+        record.update(gates)
+        self.entries.append(record)
+
+    def to_frame(self) -> pd.DataFrame:
+        if not self.entries:
+            return pd.DataFrame(columns=["timestamp"])
+        return pd.DataFrame(self.entries).set_index("timestamp")

--- a/hurricane_spy/execution.py
+++ b/hurricane_spy/execution.py
@@ -1,0 +1,311 @@
+"""Trading execution utilities for Hurricane SPY using the Alpaca API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+import json
+import math
+import os
+from urllib import error, request
+
+
+@dataclass
+class AlpacaCredentials:
+    """Credentials for authenticating with Alpaca."""
+
+    api_key: str
+    secret_key: str
+    base_url: str = "https://paper-api.alpaca.markets"
+
+    @classmethod
+    def from_env(cls) -> "AlpacaCredentials":
+        """Load credentials from the standard environment variables."""
+
+        api_key = os.getenv("ALPACA_API_KEY")
+        secret_key = os.getenv("ALPACA_SECRET_KEY")
+        if not api_key or not secret_key:
+            raise EnvironmentError(
+                "ALPACA_API_KEY and ALPACA_SECRET_KEY environment variables must be set"
+            )
+        base_url = os.getenv("ALPACA_BASE_URL", cls.base_url)
+        return cls(api_key=api_key, secret_key=secret_key, base_url=base_url)
+
+
+class AlpacaClient:
+    """Light-weight REST client for interacting with Alpaca trading endpoints."""
+
+    def __init__(self, credentials: AlpacaCredentials) -> None:
+        self.credentials = credentials
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "APCA-API-KEY-ID": self.credentials.api_key,
+            "APCA-API-SECRET-KEY": self.credentials.secret_key,
+            "Content-Type": "application/json",
+        }
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> Dict[str, Any]:
+        url = f"{self.credentials.base_url.rstrip('/')}{path}"
+        data = kwargs.pop("json", None)
+        headers = self._headers()
+        if data is not None:
+            body = json.dumps(data).encode("utf-8")
+        else:
+            body = None
+        req = request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with request.urlopen(req, timeout=10) as response:  # type: ignore[arg-type]
+                text = response.read().decode("utf-8")
+                if not text:
+                    return {}
+                return json.loads(text)
+        except error.HTTPError as exc:
+            if exc.code == 404:
+                raise FileNotFoundError(path) from exc
+            message = exc.read().decode("utf-8") if exc.fp else exc.reason
+            raise RuntimeError(f"Alpaca request failed ({exc.code}): {message}") from exc
+        except error.URLError as exc:
+            raise ConnectionError(f"Failed to reach Alpaca endpoint: {exc.reason}") from exc
+
+    def get_account(self) -> Dict[str, Any]:
+        """Return the Alpaca account details."""
+
+        return self._request("GET", "/v2/account")
+
+    def get_position(self, symbol: str) -> float:
+        """Return the current position quantity for the given symbol."""
+
+        try:
+            payload = self._request("GET", f"/v2/positions/{symbol}")
+        except FileNotFoundError:
+            return 0.0
+        qty = payload.get("qty") or payload.get("quantity") or 0
+        try:
+            return float(qty)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def submit_order(
+        self,
+        symbol: str,
+        qty: float,
+        side: str,
+        order_type: str = "market",
+        time_in_force: str = "day",
+    ) -> Dict[str, Any]:
+        """Submit an order and return the API response."""
+
+        payload = {
+            "symbol": symbol,
+            "qty": f"{abs(qty):.4f}",
+            "side": side,
+            "type": order_type,
+            "time_in_force": time_in_force,
+        }
+        return self._request("POST", "/v2/orders", json=payload)
+
+    def close_position(self, symbol: str) -> Dict[str, Any]:
+        """Close the entire open position for the given symbol."""
+
+        return self._request("DELETE", f"/v2/positions/{symbol}")
+
+
+@dataclass
+class TradingConfig:
+    """Risk and execution settings for converting pipeline signals into trades."""
+
+    symbol: str
+    base_position_size: float
+    max_position: float
+    min_order_size: float = 1.0
+    confidence_threshold: float = 0.2
+    flatten_on_abstain: bool = True
+    speed_position_scale: float = 1.0
+    direction_score_threshold: float = 0.1
+    max_hurricane_intensity: float = 4.5
+    position_tolerance: float = 0.1
+    time_in_force: str = "day"
+    order_type: str = "market"
+
+
+@dataclass
+class TradeDecision:
+    """Structured description of the chosen trading action."""
+
+    action: str
+    target_position: float
+    order_quantity: float
+    confidence: float
+    reason: str
+    side: Optional[str] = None
+    order_response: Optional[Mapping[str, Any]] = None
+
+
+class HurricaneTrader:
+    """Bridge Hurricane SPY predictions with Alpaca order execution."""
+
+    def __init__(
+        self,
+        pipeline: Any,
+        alpaca: AlpacaClient,
+        trading_config: TradingConfig,
+    ) -> None:
+        self.pipeline = pipeline
+        self.alpaca = alpaca
+        self.config = trading_config
+
+    def _weights(self, aggregate: Mapping[str, Any], timeframes: Mapping[str, Mapping[str, Any]]) -> Mapping[str, float]:
+        weights = aggregate.get("weights")
+        if weights:
+            return weights
+        fallback_weight = 1.0 / max(len(timeframes), 1)
+        return {name: fallback_weight for name in timeframes}
+
+    def _aggregate_probability(
+        self,
+        aggregate: Mapping[str, Any],
+        timeframes: Mapping[str, Mapping[str, Any]],
+    ) -> float:
+        if "probability" in aggregate:
+            return float(aggregate["probability"])
+        weights = self._weights(aggregate, timeframes)
+        return float(
+            sum(weights[name] * timeframes[name].get("probability", 0.5) for name in weights)
+        )
+
+    def _aggregate_intensity(
+        self,
+        aggregate: Mapping[str, Any],
+        timeframes: Mapping[str, Mapping[str, Any]],
+    ) -> float:
+        if "hurricane_intensity" in aggregate:
+            return float(aggregate["hurricane_intensity"])
+        weights = self._weights(aggregate, timeframes)
+        return float(
+            sum(weights[name] * timeframes[name].get("hurricane_intensity", 0.0) for name in weights)
+        )
+
+    def _derive_signal(
+        self,
+        aggregate: Mapping[str, Any],
+        probability_up: float,
+    ) -> Tuple[str, float]:
+        direction_score = float(aggregate.get("direction_score", 0.0))
+        if direction_score > self.config.direction_score_threshold:
+            direction = "up"
+        elif direction_score < -self.config.direction_score_threshold:
+            direction = "down"
+        else:
+            return "abstain", 0.0
+
+        if direction == "up":
+            directional_confidence = probability_up
+        else:
+            directional_confidence = 1.0 - probability_up
+        confidence = max(0.0, min(1.0, 2.0 * (directional_confidence - 0.5)))
+        return direction, confidence
+
+    def _target_position(self, direction: str, confidence: float, speed: float) -> float:
+        base_size = self.config.base_position_size
+        speed_component = self.config.speed_position_scale * max(speed, 0.0)
+        raw_target = (base_size + speed_component) * confidence
+        raw_target = min(raw_target, self.config.max_position)
+        if direction == "down":
+            raw_target *= -1.0
+        return raw_target
+
+    def _build_decision(
+        self,
+        aggregate: Mapping[str, Any],
+        timeframes: Mapping[str, Mapping[str, Any]],
+        current_position: float,
+    ) -> TradeDecision:
+        probability_up = self._aggregate_probability(aggregate, timeframes)
+        direction, confidence = self._derive_signal(aggregate, probability_up)
+
+        intensity = self._aggregate_intensity(aggregate, timeframes)
+        if intensity >= self.config.max_hurricane_intensity:
+            return TradeDecision(
+                action="hold",
+                target_position=current_position,
+                order_quantity=0.0,
+                confidence=confidence,
+                reason=f"intensity {intensity:.2f} exceeds limit",
+            )
+
+        if direction == "abstain":
+            if self.config.flatten_on_abstain and abs(current_position) > self.config.position_tolerance:
+                return TradeDecision(
+                    action="flatten",
+                    target_position=0.0,
+                    order_quantity=abs(current_position),
+                    confidence=confidence,
+                    reason="abstention triggered flatten",
+                    side="sell" if current_position > 0 else "buy",
+                )
+            return TradeDecision(
+                action="hold",
+                target_position=current_position,
+                order_quantity=0.0,
+                confidence=confidence,
+                reason="abstain",
+            )
+
+        if confidence < self.config.confidence_threshold:
+            return TradeDecision(
+                action="hold",
+                target_position=current_position,
+                order_quantity=0.0,
+                confidence=confidence,
+                reason=f"confidence {confidence:.2f} below threshold",
+            )
+
+        speed = float(aggregate.get("speed", 0.0))
+        target_position = self._target_position(direction, confidence, speed)
+        delta = target_position - current_position
+        if abs(delta) < self.config.min_order_size or math.isclose(delta, 0.0, abs_tol=self.config.position_tolerance):
+            return TradeDecision(
+                action="hold",
+                target_position=current_position,
+                order_quantity=0.0,
+                confidence=confidence,
+                reason="change below order size threshold",
+            )
+
+        side = "buy" if delta > 0 else "sell"
+        return TradeDecision(
+            action=side,
+            target_position=target_position,
+            order_quantity=abs(delta),
+            confidence=confidence,
+            reason="rebalance toward target",
+            side=side,
+        )
+
+    def execute(self, data_bundle: Any) -> Tuple[Dict[str, Any], TradeDecision]:
+        """Run the pipeline, derive an execution decision, and place orders if needed."""
+
+        result = self.pipeline.run(data_bundle)
+        aggregate = result["aggregate"]
+        timeframes = result["timeframes"]
+        current_position = self.alpaca.get_position(self.config.symbol)
+        decision = self._build_decision(aggregate, timeframes, current_position)
+
+        order_response: Optional[Mapping[str, Any]] = None
+        if decision.action == "flatten":
+            order_response = self.alpaca.close_position(self.config.symbol)
+        elif decision.action in ("buy", "sell"):
+            order_response = self.alpaca.submit_order(
+                symbol=self.config.symbol,
+                qty=decision.order_quantity,
+                side=decision.side or decision.action,
+                order_type=self.config.order_type,
+                time_in_force=self.config.time_in_force,
+            )
+
+        if order_response is not None:
+            decision.order_response = order_response
+
+        return result, decision

--- a/hurricane_spy/features.py
+++ b/hurricane_spy/features.py
@@ -1,0 +1,171 @@
+"""Feature engineering primitives for the Hurricane SPY pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Tuple
+
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+
+
+@dataclass
+class DirectionInputs:
+    sign_gex: float
+    delta_dix: float
+    technical_alignment: float
+    ofi: float
+    theta: Tuple[float, float, float, float]
+    threshold: float
+
+
+def hurricane_intensity(
+    realised_vol: float,
+    base_vol: float,
+    drift: float,
+    avg_gamma: float,
+    alpha: float,
+    beta: float,
+) -> int:
+    r"""Compute the discrete hurricane intensity scale.
+
+    Parameters
+    ----------
+    realised_vol:
+        Observed volatility (``\\sigma_{t,T}``) for timeframe ``T``.
+    base_vol:
+        Baseline volatility (``\\sigma_{0,T}``) used for comparison.
+    drift:
+        Absolute value of the drift estimate ``|\mu_{t,T}|``.
+    avg_gamma:
+        Average gamma exposure normalised to ``[0, 1]``.
+    alpha, beta:
+        Scaling coefficients as per the whitepaper.
+    """
+
+    if realised_vol <= 0 or base_vol <= 0:
+        raise ValueError("Volatility inputs must be positive")
+    log_ratio = np.log(realised_vol / base_vol) / np.log(2)
+    intensity = np.floor(
+        np.clip(log_ratio + alpha * np.abs(drift) + beta * avg_gamma, 0.0, 5.0)
+    )
+    return int(intensity)
+
+
+def level_score(level_row: pd.Series, weights: Mapping[str, float]) -> float:
+    """Compute the composite score for a single price level."""
+
+    return (
+        weights.get("gamma", 0.0) * level_row.get("gamma_score", 0.0)
+        + weights.get("dark_pool", 0.0) * level_row.get("dark_pool_score", 0.0)
+        + weights.get("volume", 0.0) * level_row.get("volume_score", 0.0)
+    )
+
+
+def support_resistance_potential(
+    price: float, levels: pd.DataFrame, weights: Mapping[str, float], lambda_level: float
+) -> float:
+    r"""Compute the support/resistance potential field ``\\Phi(p)``."""
+
+    if lambda_level <= 0:
+        raise ValueError("lambda_level must be positive")
+    scores = levels.apply(level_score, axis=1, weights=weights)
+    distances = (price - levels["level"]) / lambda_level
+    kernel = 1.0 / (1.0 + distances**2)
+    return float(np.sum(scores * kernel))
+
+
+def direction_estimate(inputs: DirectionInputs) -> float:
+    r"""Estimate the signed drift ``\\mu_{t,T}`` using the provided inputs."""
+
+    theta_1, theta_2, theta_3, theta_4 = inputs.theta
+    mu = (
+        theta_1 * inputs.sign_gex
+        + theta_2 * inputs.delta_dix
+        + theta_3 * inputs.technical_alignment
+        + theta_4 * inputs.ofi
+    )
+    if np.abs(mu) < inputs.threshold:
+        return 0.0
+    return float(mu)
+
+
+def direction_signal(mu: float, abstention_threshold: float) -> str:
+    """Convert a drift estimate into an actionable signal with abstention."""
+
+    if np.abs(mu) <= abstention_threshold:
+        return "abstain"
+    return "up" if mu > 0 else "down"
+
+
+def speed_forecast(
+    realised_vol: float,
+    alpha_v: float,
+    beta_v: float,
+    chi_v: float,
+    upsilon: float,
+    gap_to_level: float,
+    hurricane_intensity: float,
+) -> float:
+    """Compute the expected magnitude per unit time (speed forecast)."""
+
+    if realised_vol < 0:
+        raise ValueError("Realised volatility must be non-negative")
+    return float(
+        realised_vol * (1 + alpha_v * upsilon + beta_v * gap_to_level + chi_v * hurricane_intensity)
+    )
+
+
+def finite_horizon_barrier_probability(
+    price: float,
+    drift: float,
+    vol: float,
+    barrier: Mapping[str, float],
+    horizon: float,
+) -> float:
+    """Finite-horizon probability of hitting the lower barrier before expiry."""
+
+    if vol <= 0 or horizon <= 0:
+        raise ValueError("vol and horizon must be positive")
+    lower = barrier["lower"]
+    upper = barrier.get("upper", np.inf)
+    if not np.isfinite(upper):
+        return float(1.0)
+    numerator = norm.cdf((lower - price - drift * horizon) / (vol * np.sqrt(horizon)))
+    exp_term = np.exp(2 * drift * (lower - price) / (vol**2))
+    second_term = exp_term * norm.cdf((lower - price + drift * horizon) / (vol * np.sqrt(horizon)))
+    return float(1 - (numerator - second_term))
+
+
+def expected_abs_normal(mu: float, sigma: float) -> float:
+    """Expected absolute value of a normal random variable."""
+
+    if sigma <= 0:
+        raise ValueError("sigma must be positive")
+    return float(
+        sigma * np.sqrt(2 / np.pi) * np.exp(-(mu**2) / (2 * sigma**2))
+        + mu * (1 - 2 * norm.cdf(-mu / sigma))
+    )
+
+
+def conformal_interval(residuals: Iterable[float], alpha: float) -> float:
+    """Return the (1-alpha) conformal quantile width."""
+
+    if not 0 < alpha < 1:
+        raise ValueError("alpha must be in (0,1)")
+    residuals = np.abs(np.array(list(residuals)))
+    if residuals.size == 0:
+        return 0.0
+    q = np.quantile(residuals, 1 - alpha, interpolation="higher")
+    return float(q)
+
+
+def brier_score(probability: float, outcome: float) -> float:
+    """Compute the Brier score for a binary outcome."""
+
+    if not 0 <= probability <= 1:
+        raise ValueError("probability must be within [0,1]")
+    if outcome not in (0, 1):
+        raise ValueError("outcome must be binary")
+    return float((probability - outcome) ** 2)

--- a/hurricane_spy/gating.py
+++ b/hurricane_spy/gating.py
@@ -1,0 +1,97 @@
+"""Stability and abstention modules for Hurricane SPY."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, MutableMapping
+
+import pandas as pd
+
+
+@dataclass
+class EventAbstention:
+    """Event-aware abstention logic."""
+
+    cooling_window: int
+
+    def __call__(self, events: pd.Series, timestamp: pd.Timestamp) -> bool:
+        if events is None or events.empty or "is_event" not in events.index:
+            return False
+        if events["is_event"]:
+            return True
+        if "minutes_to_event" in events.index:
+            return events["minutes_to_event"] <= self.cooling_window
+        return False
+
+
+@dataclass
+class CusumRegimeFlipDetector:
+    """CUSUM-based regime flip detector."""
+
+    threshold: float
+    drift: float
+
+    def update(self, series: pd.Series) -> float:
+        returns = series.diff().dropna()
+        if returns.empty:
+            return 0.0
+        g_pos = 0.0
+        g_neg = 0.0
+        flip_signal = 0.0
+        for r in returns:
+            g_pos = max(0.0, g_pos + r - self.drift)
+            g_neg = min(0.0, g_neg + r + self.drift)
+            if g_pos > self.threshold:
+                flip_signal = max(flip_signal, g_pos)
+                g_pos = 0.0
+            if abs(g_neg) > self.threshold:
+                flip_signal = min(flip_signal, g_neg)
+                g_neg = 0.0
+        return flip_signal
+
+
+@dataclass
+class ExogenousFlowGate:
+    limit: float
+
+    def __call__(self, ofi_row: pd.Series) -> bool:
+        value = ofi_row.get("exogenous_flow", 0.0)
+        return abs(value) > self.limit
+
+
+@dataclass
+class HedgingPressureGate:
+    limit: float
+
+    def __call__(self, greeks_row: pd.Series) -> bool:
+        gamma = abs(greeks_row.get("gamma", 0.0))
+        vanna = abs(greeks_row.get("vanna", 0.0))
+        charm = abs(greeks_row.get("charm", 0.0))
+        pressure = gamma + 0.5 * vanna + 0.25 * charm
+        return pressure > self.limit
+
+
+def apply_gates(
+    timestamp: pd.Timestamp,
+    events: pd.Series,
+    price_history: pd.Series,
+    ofi_row: pd.Series,
+    greeks_row: pd.Series,
+    gates: Mapping[str, object],
+) -> Dict[str, bool]:
+    """Evaluate all gating modules and return their boolean status."""
+
+    results: MutableMapping[str, bool] = {}
+    event_gate = gates.get("event")
+    if isinstance(event_gate, EventAbstention):
+        results["event"] = event_gate(events, timestamp)
+    regime_gate = gates.get("regime")
+    if isinstance(regime_gate, CusumRegimeFlipDetector):
+        results["regime_flip"] = regime_gate.update(price_history)
+    flow_gate = gates.get("flow")
+    if isinstance(flow_gate, ExogenousFlowGate):
+        results["exogenous_flow"] = flow_gate(ofi_row)
+    hedging_gate = gates.get("hedging")
+    if isinstance(hedging_gate, HedgingPressureGate):
+        results["hedging_pressure"] = hedging_gate(greeks_row)
+    return dict(results)

--- a/hurricane_spy/pipeline.py
+++ b/hurricane_spy/pipeline.py
@@ -1,0 +1,183 @@
+"""Pipeline orchestration for the Hurricane SPY algorithm."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Dict, Mapping
+
+import numpy as np
+import pandas as pd
+
+from .aggregation import StressWeightedGMV
+from .config import HurricaneConfig, TimeframeConfig
+from .data_structures import MarketDataBundle
+from .diagnostics import GatingDiagnostics, ReliabilityTracker
+from .features import (
+    DirectionInputs,
+    conformal_interval,
+    direction_estimate,
+    direction_signal,
+    expected_abs_normal,
+    finite_horizon_barrier_probability,
+    hurricane_intensity,
+    speed_forecast,
+    support_resistance_potential,
+)
+from .gating import (
+    CusumRegimeFlipDetector,
+    EventAbstention,
+    ExogenousFlowGate,
+    HedgingPressureGate,
+    apply_gates,
+)
+
+
+class HurricaneSPY:
+    """End-to-end execution of the Hurricane SPY inference pipeline."""
+
+    def __init__(self, config: HurricaneConfig) -> None:
+        self.config = config
+        self.aggregator = StressWeightedGMV(
+            tikhonov=config.gmvtikhonov, stress_weight=config.stress_weight
+        )
+        self.reliability = ReliabilityTracker()
+        self.gating_diagnostics = GatingDiagnostics()
+
+    def _build_gates(self) -> Dict[str, object]:
+        return {
+            "event": EventAbstention(self.config.cooling_window),
+            "regime": CusumRegimeFlipDetector(
+                threshold=self.config.cusum_threshold, drift=self.config.cusum_drift
+            ),
+            "flow": ExogenousFlowGate(self.config.exogenous_flow_limit),
+            "hedging": HedgingPressureGate(self.config.hedging_pressure_limit),
+        }
+
+    def run(self, data: MarketDataBundle) -> Dict[str, object]:
+        """Execute the Hurricane SPY pipeline on the provided data bundle."""
+
+        timeframe_names = [tf.name for tf in self.config.timeframes]
+        data.validate(timeframe_names)
+        latest = data.latest()
+        price_series = data.price["close"]
+        gates = self._build_gates()
+        per_timeframe: Dict[str, Dict[str, object]] = {}
+        covariance_entries = []
+
+        for tf in self.config.timeframes:
+            tf_result = self._run_timeframe(tf, data, latest, price_series, gates)
+            per_timeframe[tf.name] = tf_result
+            covariance_entries.append(tf_result["speed_vol_proxy"])
+
+        covariance = pd.DataFrame(
+            np.diag(covariance_entries), index=timeframe_names, columns=timeframe_names
+        )
+        stress_level = float(latest.get("stress", 0.0))
+        aggregated = self.aggregator(
+            {name: per_timeframe[name] for name in timeframe_names}, covariance, stress_level
+        )
+        diagnostics = {
+            "gating": self.gating_diagnostics.to_frame(),
+            "reliability": self.reliability.summary(),
+        }
+        return {
+            "timeframes": per_timeframe,
+            "aggregate": aggregated,
+            "diagnostics": diagnostics,
+        }
+
+    def _run_timeframe(
+        self,
+        tf: TimeframeConfig,
+        data: MarketDataBundle,
+        latest: Mapping[str, pd.Series],
+        price_series: pd.Series,
+        gates: Mapping[str, object],
+    ) -> Dict[str, object]:
+        timestamp = price_series.index[-1]
+        price = float(latest["price"]["close"])
+        levels = data.levels[data.levels.index == data.levels.index.max()]
+        sr_potential = support_resistance_potential(
+            price, levels, tf.weights, tf.lambda_level
+        )
+        nearest_position = (levels["level"] - price).abs().values.argmin()
+        nearest_level = float(levels.iloc[nearest_position]["level"])
+        gap_to_level = float(abs(price - nearest_level) / max(price, 1e-6))
+
+        greeks_row = latest["greeks"]
+        ofi_row = latest["ofi"]
+        sign_gex = np.sign(greeks_row.get("gamma", 0.0))
+        dix_series = data.ofi["dark_pool_index"] if "dark_pool_index" in data.ofi else None
+        delta_dix = float(dix_series.diff().iloc[-1]) if dix_series is not None else 0.0
+        technical_alignment = float(data.technical[tf.name].iloc[-1])
+        ofi_value = float(ofi_row["ofi"])
+        theta = (0.35, 0.25, 0.2, 0.2)
+        mu = direction_estimate(
+            DirectionInputs(
+                sign_gex=sign_gex,
+                delta_dix=float(delta_dix) if not np.isnan(delta_dix) else 0.0,
+                technical_alignment=technical_alignment,
+                ofi=ofi_value,
+                theta=theta,
+                threshold=tf.direction_threshold,
+            )
+        )
+        realised_vol = float(data.realised_vol[tf.name].iloc[-1])
+        base_vol = float(data.base_vol[tf.name])
+        avg_gamma = float(np.tanh(abs(greeks_row.get("gamma", 0.0))))
+        intensity = hurricane_intensity(
+            realised_vol, base_vol, mu, avg_gamma, self.config.hurricane_alpha, self.config.hurricane_beta
+        )
+        upsilon = float(abs(ofi_row.get("variance_amplifier", ofi_value)))
+        alpha_v, beta_v, chi_v = tf.speed_coefficients
+        speed = speed_forecast(
+            realised_vol, alpha_v, beta_v, chi_v, upsilon, gap_to_level, intensity
+        )
+        signal = direction_signal(mu, tf.abstention_threshold)
+        probability = float(0.5 + 0.5 * np.tanh(mu))
+
+        barrier_prob = None
+        if data.barrier_levels and tf.name in data.barrier_levels:
+            barrier_prob = finite_horizon_barrier_probability(
+                price=price,
+                drift=mu,
+                vol=realised_vol,
+                barrier=data.barrier_levels[tf.name],
+                horizon=tf.horizon_minutes / 60.0,
+            )
+
+        residuals = np.abs(data.price["close"].diff().dropna())
+        conformal_width = conformal_interval(residuals.tail(250), alpha=0.1)
+
+        expected_move = expected_abs_normal(mu, realised_vol + 1e-6)
+
+        gate_results = apply_gates(
+            timestamp=timestamp,
+            events=latest.get("events", pd.Series(dtype=float)),
+            price_history=price_series,
+            ofi_row=ofi_row,
+            greeks_row=greeks_row,
+            gates=gates,
+        )
+        self.gating_diagnostics.log(timestamp, gate_results)
+        blocked = any(bool(flag) for flag in gate_results.values())
+        if blocked:
+            signal = "abstain"
+        self.reliability.update("storm" if intensity >= 4 else "trend", probability, 1 if mu > 0 else 0)
+
+        return {
+            "timestamp": timestamp,
+            "support_resistance": sr_potential,
+            "direction_score": mu,
+            "direction_signal": signal,
+            "probability": probability,
+            "speed": speed,
+            "speed_vol_proxy": realised_vol + intensity,
+            "hurricane_intensity": intensity,
+            "gap_to_level": gap_to_level,
+            "expected_move": expected_move,
+            "conformal_width": conformal_width,
+            "barrier_hit_probability": barrier_prob,
+            "gates": gate_results,
+            "config": asdict(tf),
+        }

--- a/hurricane_spy/scripts/run_pipeline.py
+++ b/hurricane_spy/scripts/run_pipeline.py
@@ -1,0 +1,104 @@
+"""Example entry-point for running the Hurricane SPY pipeline."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import numpy as np
+import pandas as pd
+
+from hurricane_spy import HurricaneConfig, HurricaneSPY, TimeframeConfig
+from hurricane_spy.data_structures import MarketDataBundle
+
+
+def generate_dummy_data(index: pd.DatetimeIndex) -> MarketDataBundle:
+    price = pd.DataFrame(
+        {
+            "open": 430 + np.cumsum(np.random.normal(0, 0.3, size=len(index))),
+            "high": 431 + np.cumsum(np.random.normal(0, 0.35, size=len(index))),
+            "low": 429 + np.cumsum(np.random.normal(0, 0.35, size=len(index))),
+            "close": 430 + np.cumsum(np.random.normal(0, 0.3, size=len(index))),
+            "volume": 1_000_000 + np.random.normal(0, 50_000, size=len(index)),
+        },
+        index=index,
+    )
+    greeks = pd.DataFrame(
+        {
+            "gamma": np.random.normal(0, 0.5, size=len(index)),
+            "vanna": np.random.normal(0, 0.3, size=len(index)),
+            "charm": np.random.normal(0, 0.2, size=len(index)),
+        },
+        index=index,
+    )
+    ofi = pd.DataFrame(
+        {
+            "ofi": np.random.normal(0, 1, size=len(index)),
+            "dark_pool_index": np.random.normal(0, 0.2, size=len(index)).cumsum(),
+            "exogenous_flow": np.random.normal(0, 0.5, size=len(index)),
+            "variance_amplifier": np.random.uniform(0, 1, size=len(index)),
+        },
+        index=index,
+    )
+    technical = {
+        "1m": pd.Series(np.tanh(np.random.normal(0, 0.8, size=len(index))), index=index),
+        "5m": pd.Series(np.tanh(np.random.normal(0, 0.6, size=len(index))), index=index),
+        "30m": pd.Series(np.tanh(np.random.normal(0, 0.4, size=len(index))), index=index),
+    }
+    levels_index = pd.Index([index[-1]] * 5)
+    levels = pd.DataFrame(
+        {
+            "level": np.linspace(420, 440, 5),
+            "gamma_score": np.random.uniform(-1, 1, 5),
+            "dark_pool_score": np.random.uniform(-1, 1, 5),
+            "volume_score": np.random.uniform(-1, 1, 5),
+        },
+        index=levels_index,
+    )
+    realised_vol = {
+        "1m": pd.Series(np.random.uniform(0.5, 1.2, len(index)), index=index),
+        "5m": pd.Series(np.random.uniform(0.4, 1.0, len(index)), index=index),
+        "30m": pd.Series(np.random.uniform(0.3, 0.8, len(index)), index=index),
+    }
+    base_vol = {"1m": 0.4, "5m": 0.35, "30m": 0.25}
+    barrier_levels = {
+        "1m": {"lower": 420.0, "upper": 440.0},
+        "5m": {"lower": 418.0, "upper": 442.0},
+        "30m": {"lower": 410.0, "upper": 448.0},
+    }
+    events = pd.DataFrame({"is_event": [False] * len(index)}, index=index)
+    stress_index = pd.Series(np.random.uniform(0, 1, len(index)), index=index)
+    return MarketDataBundle(
+        price=price,
+        greeks=greeks,
+        ofi=ofi,
+        technical=technical,
+        levels=levels,
+        realised_vol=realised_vol,
+        base_vol=base_vol,
+        barrier_levels=barrier_levels,
+        events=events,
+        stress_index=stress_index,
+    )
+
+
+def main() -> None:
+    index = pd.date_range(end=datetime.now(UTC), periods=500, freq="min")
+    bundle = generate_dummy_data(index)
+    config = HurricaneConfig(
+        timeframes=[
+            TimeframeConfig(name="1m", horizon_minutes=1, abstention_threshold=0.05, lambda_level=0.75),
+            TimeframeConfig(name="5m", horizon_minutes=5, abstention_threshold=0.06, lambda_level=1.0),
+            TimeframeConfig(name="30m", horizon_minutes=30, abstention_threshold=0.08, lambda_level=1.5),
+        ]
+    )
+    pipeline = HurricaneSPY(config)
+    result = pipeline.run(bundle)
+    print("Aggregate Predictions:\n", result["aggregate"])
+    print("\nPer Timeframe:")
+    for name, payload in result["timeframes"].items():
+        print(f"- {name}: signal={payload['direction_signal']}, speed={payload['speed']:.3f}")
+    print("\nDiagnostics head:\n", result["diagnostics"]["gating"].head())
+
+
+if __name__ == "__main__":
+    main()

--- a/hurricane_spy/scripts/run_trading.py
+++ b/hurricane_spy/scripts/run_trading.py
@@ -1,0 +1,217 @@
+"""Example script wiring Hurricane SPY predictions to Alpaca execution."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+import requests
+
+from hurricane_spy import (
+    AlpacaClient,
+    AlpacaCredentials,
+    HurricaneConfig,
+    HurricaneSPY,
+    HurricaneTrader,
+    TimeframeConfig,
+    TradingConfig,
+    UnusualWhalesClient,
+    assemble_bundle,
+    merge_unusual_whales_signals,
+)
+from hurricane_spy.data_sources import align_series
+from hurricane_spy.data_structures import MarketDataBundle
+from hurricane_spy.scripts.run_pipeline import generate_dummy_data
+
+LOGGER = logging.getLogger(__name__)
+
+
+def fetch_alpaca_bars(
+    credentials: AlpacaCredentials,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+) -> pd.DataFrame:
+    """Fetch 1-minute bars from the Alpaca market data API."""
+
+    data_base_url = os.getenv("ALPACA_DATA_BASE_URL", "https://data.alpaca.markets")
+    url = f"{data_base_url.rstrip('/')}/v2/stocks/{symbol}/bars"
+    params = {
+        "timeframe": "1Min",
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "adjustment": "raw",
+        "limit": 10_000,
+    }
+    headers = {
+        "APCA-API-KEY-ID": credentials.api_key,
+        "APCA-API-SECRET-KEY": credentials.secret_key,
+    }
+    response = requests.get(url, params=params, headers=headers, timeout=10)
+    response.raise_for_status()
+    bars = response.json().get("bars", [])
+    frame = pd.DataFrame(bars)
+    if frame.empty:
+        raise ValueError("Alpaca data API returned no bars")
+    frame["timestamp"] = pd.to_datetime(frame["t"], utc=True)
+    frame = frame.set_index("timestamp").sort_index()
+    frame = frame.rename(columns={"o": "open", "h": "high", "l": "low", "c": "close", "v": "volume"})
+    return frame[["open", "high", "low", "close", "volume"]].astype(float)
+
+
+def build_live_bundle(
+    *,
+    symbol: str,
+    credentials: AlpacaCredentials,
+    lookback: timedelta,
+) -> Tuple[MarketDataBundle, bool]:
+    """Attempt to build a MarketDataBundle from live data sources."""
+
+    token = os.getenv("UNUSUAL_WHALES_API_TOKEN")
+    end = datetime.now(UTC)
+    start = end - lookback
+    if not token:
+        return generate_dummy_data(pd.date_range(end=end, periods=500, freq="min")), False
+
+    client = UnusualWhalesClient(api_token=token)
+    try:
+        flow = client.fetch_options_flow(symbol, start=start, end=end, limit=5000)
+        dark_pool = client.fetch_dark_pool_activity(symbol, start=start, end=end)
+        gex = client.fetch_gamma_exposure(symbol, start=start, end=end)
+        ofi = merge_unusual_whales_signals(flow=flow, dark_pool=dark_pool, gex=gex)
+    except Exception as exc:  # pragma: no cover - network
+        LOGGER.warning("Failed to load Unusual Whales data (%s); falling back to dummy bundle", exc)
+        return generate_dummy_data(pd.date_range(end=end, periods=500, freq="min")), False
+
+    try:
+        price = fetch_alpaca_bars(credentials, symbol, start=start, end=end)
+    except Exception as exc:  # pragma: no cover - network
+        LOGGER.warning("Failed to load Alpaca price history (%s); falling back to dummy bundle", exc)
+        return generate_dummy_data(pd.date_range(end=end, periods=500, freq="min")), False
+
+    shared_index = align_series([price["close"], ofi["ofi"]], rule="1min")
+    price = price.resample("1min").last().reindex(shared_index).interpolate().ffill()
+    ofi = ofi.reindex(shared_index).ffill().bfill()
+
+    greeks_raw = gex.copy()
+    if "timestamp" in greeks_raw:
+        greeks_raw["timestamp"] = pd.to_datetime(greeks_raw["timestamp"], utc=True)
+        greeks_raw = greeks_raw.set_index("timestamp").sort_index()
+    greeks_raw = greeks_raw.resample("1min").mean().reindex(shared_index).interpolate().fillna(0.0)
+    greeks = pd.DataFrame(index=shared_index)
+    greeks["gamma"] = greeks_raw.filter(regex="gamma|gex", axis=1).sum(axis=1)
+    greeks["vanna"] = greeks_raw.filter(regex="vanna|delta", axis=1).sum(axis=1)
+    greeks["charm"] = greeks_raw.filter(regex="charm|theta", axis=1).sum(axis=1)
+    greeks = greeks.fillna(0.0)
+
+    close = price["close"]
+    returns = close.pct_change().fillna(0.0)
+    realised_vol = {
+        "1m": returns.rolling(30).std().fillna(method="bfill") * np.sqrt(390),
+        "5m": returns.rolling(150).std().fillna(method="bfill") * np.sqrt(390 / 5),
+        "30m": returns.rolling(900).std().fillna(method="bfill") * np.sqrt(390 / 30),
+    }
+    base_vol = {"1m": 0.35, "5m": 0.3, "30m": 0.25}
+
+    def _technical(window: int) -> pd.Series:
+        ma = close.rolling(window).mean()
+        std = close.rolling(window).std().replace(0, np.nan)
+        score = (close - ma) / std
+        return score.clip(-1, 1).fillna(0.0)
+
+    technical = {
+        "1m": _technical(20),
+        "5m": _technical(60),
+        "30m": _technical(180),
+    }
+
+    last_close = float(close.iloc[-1])
+    levels = pd.DataFrame(
+        {
+            "level": np.linspace(last_close * 0.95, last_close * 1.05, 5),
+            "gamma_score": np.linspace(-1, 1, 5),
+            "dark_pool_score": np.tanh(ofi["dark_pool_index"].iloc[-1] / 1_000 if "dark_pool_index" in ofi else 0.0),
+            "volume_score": np.linspace(-0.5, 0.5, 5),
+        },
+        index=pd.Index([shared_index[-1]] * 5),
+    )
+
+    barrier_levels = {
+        "1m": {"lower": last_close * 0.97, "upper": last_close * 1.03},
+        "5m": {"lower": last_close * 0.95, "upper": last_close * 1.05},
+        "30m": {"lower": last_close * 0.9, "upper": last_close * 1.1},
+    }
+    events = pd.DataFrame({"is_event": False}, index=shared_index)
+    stress_index = (returns.abs().rolling(120).mean() * 100).clip(0, 10)
+
+    bundle = assemble_bundle(
+        price=price,
+        greeks=greeks,
+        ofi=ofi,
+        technical=technical,
+        levels=levels,
+        realised_vol=realised_vol,
+        base_vol=base_vol,
+        barrier_levels=barrier_levels,
+        events=events,
+        stress_index=stress_index,
+    )
+    return bundle, True
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    credentials = AlpacaCredentials.from_env()
+
+    lookback = timedelta(hours=float(os.getenv("HURRICANE_LOOKBACK_HOURS", "6")))
+    symbol = os.getenv("HURRICANE_SYMBOL", "SPY")
+    bundle, live = build_live_bundle(symbol=symbol, credentials=credentials, lookback=lookback)
+
+    config = HurricaneConfig(
+        timeframes=[
+            TimeframeConfig(name="1m", horizon_minutes=1, abstention_threshold=0.05, lambda_level=0.75),
+            TimeframeConfig(name="5m", horizon_minutes=5, abstention_threshold=0.06, lambda_level=1.0),
+            TimeframeConfig(name="30m", horizon_minutes=30, abstention_threshold=0.08, lambda_level=1.5),
+        ]
+    )
+    pipeline = HurricaneSPY(config)
+
+    alpaca = AlpacaClient(credentials)
+
+    trading = TradingConfig(
+        symbol=symbol,
+        base_position_size=10,
+        max_position=100,
+        min_order_size=1,
+        confidence_threshold=0.25,
+        speed_position_scale=2.0,
+        direction_score_threshold=0.05,
+    )
+
+    trader = HurricaneTrader(pipeline=pipeline, alpaca=alpaca, trading_config=trading)
+    result, decision = trader.execute(bundle)
+
+    aggregate = result["aggregate"]
+    print("Aggregate forecasts:")
+    for key, value in aggregate.items():
+        if key == "weights":
+            continue
+        print(f"  {key}: {value}")
+
+    print("\nTrade decision:")
+    print(f"  action: {decision.action}")
+    print(f"  target_position: {decision.target_position:.2f}")
+    print(f"  order_quantity: {decision.order_quantity:.2f}")
+    print(f"  confidence: {decision.confidence:.2f}")
+    print(f"  reason: {decision.reason}")
+    if decision.order_response:
+        print("  order_response:", decision.order_response)
+    print(f"\nData source: {'Unusual Whales + Alpaca live feeds' if live else 'synthetic bundle'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy>=1.23
+pandas>=1.5
+scipy>=1.9
+requests>=2.31
+pytest>=8.0
+pytest-cov>=4.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,98 @@
+"""Pytest fixtures for Hurricane SPY tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Dict
+
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hurricane_spy import HurricaneConfig, HurricaneSPY, TimeframeConfig
+from hurricane_spy.data_structures import MarketDataBundle
+from hurricane_spy.scripts.run_pipeline import generate_dummy_data
+
+
+@pytest.fixture(scope="session")
+def timeframe_names() -> Dict[str, TimeframeConfig]:
+    """Return the canonical timeframe configuration used across tests."""
+
+    config = {
+        "1m": TimeframeConfig(
+            name="1m",
+            horizon_minutes=1,
+            abstention_threshold=0.05,
+            lambda_level=0.75,
+        ),
+        "5m": TimeframeConfig(
+            name="5m",
+            horizon_minutes=5,
+            abstention_threshold=0.06,
+            lambda_level=1.0,
+        ),
+        "30m": TimeframeConfig(
+            name="30m",
+            horizon_minutes=30,
+            abstention_threshold=0.08,
+            lambda_level=1.5,
+        ),
+    }
+    return config
+
+
+@pytest.fixture(scope="session")
+def hurricane_config(timeframe_names: Dict[str, TimeframeConfig]) -> HurricaneConfig:
+    """Provide a Hurricane configuration shared across tests."""
+
+    return HurricaneConfig(timeframes=list(timeframe_names.values()))
+
+
+@pytest.fixture
+def dummy_index() -> pd.DatetimeIndex:
+    """Deterministic timestamp index for synthetic bundles."""
+
+    return pd.date_range("2025-01-01", periods=512, freq="min", tz="UTC")
+
+
+@pytest.fixture
+def dummy_bundle(dummy_index: pd.DatetimeIndex) -> MarketDataBundle:
+    """Generate reproducible synthetic data for pipeline runs."""
+
+    np.random.seed(42)
+    return generate_dummy_data(dummy_index)
+
+
+@pytest.fixture
+def pipeline(hurricane_config: HurricaneConfig) -> HurricaneSPY:
+    """Instantiate the Hurricane pipeline under test."""
+
+    return HurricaneSPY(hurricane_config)
+
+
+@pytest.fixture
+def bundle_without_close(dummy_bundle: MarketDataBundle) -> MarketDataBundle:
+    """Bundle missing the closing price column for validation checks."""
+
+    price = dummy_bundle.price.drop(columns=["close"])
+    return replace(dummy_bundle, price=price)
+
+
+@pytest.fixture
+def bundle_with_negative_vol(dummy_bundle: MarketDataBundle) -> MarketDataBundle:
+    """Bundle containing a negative realised volatility entry."""
+
+    realised_vol = {
+        name: series.copy()
+        for name, series in dummy_bundle.realised_vol.items()
+    }
+    first_tf = next(iter(realised_vol))
+    realised_vol[first_tf].iloc[-1] = -0.1
+    return replace(dummy_bundle, realised_vol=realised_vol)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,133 @@
+"""Regression coverage for the Hurricane SPY pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hurricane_spy.aggregation import StressWeightedGMV
+from hurricane_spy.data_structures import MarketDataBundle
+
+
+@pytest.fixture
+def pipeline_result(pipeline, dummy_bundle):
+    """Run the pipeline once per test invocation for deterministic assertions."""
+
+    return pipeline.run(dummy_bundle)
+
+
+def test_pipeline_topology_and_keys(pipeline_result):
+    """The pipeline should return aggregate, per-timeframe, and diagnostics payloads."""
+
+    assert set(pipeline_result.keys()) == {"timeframes", "aggregate", "diagnostics"}
+    assert {"gating", "reliability"}.issubset(pipeline_result["diagnostics"].keys())
+    assert not pipeline_result["diagnostics"]["gating"].empty
+
+
+@pytest.mark.parametrize("timeframe", ["1m", "5m", "30m"])
+def test_timeframe_payload_structure(pipeline_result, timeframe):
+    """Each timeframe output should carry core metrics and traceability metadata."""
+
+    payload = pipeline_result["timeframes"][timeframe]
+    assert payload["direction_signal"] in {"up", "down", "abstain"}
+    assert payload["speed"] >= 0
+    assert 0.0 <= payload["probability"] <= 1.0
+    assert "gates" in payload and isinstance(payload["gates"], dict)
+    assert payload["config"]["name"] == timeframe
+
+
+def test_pipeline_abstains_during_events(pipeline, dummy_bundle):
+    """Event abstention should force signals to abstain when the latest bar is flagged."""
+
+    assert dummy_bundle.events is not None
+    events = dummy_bundle.events.copy()
+    events.iloc[-1] = True
+    bundle = replace(dummy_bundle, events=events)
+
+    result = pipeline.run(bundle)
+    for payload in result["timeframes"].values():
+        assert payload["direction_signal"] == "abstain"
+        assert payload["gates"]["event"] is True
+
+
+@pytest.mark.parametrize("stress_level", [0.0, 2.5, 5.0])
+def test_stress_weighted_gmv_allocates_to_slower_horizons(stress_level: float):
+    """Weights should normalise and emphasise slower horizons as stress increases."""
+
+    forecasts = {
+        "1m": {
+            "support_resistance": 0.1,
+            "direction_score": 0.05,
+            "speed": 0.3,
+            "probability": 0.55,
+            "hurricane_intensity": 0.2,
+        },
+        "5m": {
+            "support_resistance": 0.2,
+            "direction_score": 0.04,
+            "speed": 0.2,
+            "probability": 0.52,
+            "hurricane_intensity": 0.25,
+        },
+        "30m": {
+            "support_resistance": 0.3,
+            "direction_score": 0.03,
+            "speed": 0.1,
+            "probability": 0.5,
+            "hurricane_intensity": 0.3,
+        },
+    }
+    covariance = pd.DataFrame(
+        np.diag([0.8, 0.5, 0.3]),
+        index=["1m", "5m", "30m"],
+        columns=["1m", "5m", "30m"],
+    )
+    aggregator = StressWeightedGMV(tikhonov=1e-3, stress_weight=0.4)
+
+    weights = aggregator(forecasts, covariance, stress_level)["weights"]
+
+    assert pytest.approx(sum(weights.values()), rel=1e-6) == 1.0
+    if stress_level > 0:
+        increased = aggregator(forecasts, covariance, stress_level + 1.0)["weights"]
+        assert increased["30m"] >= weights["30m"]
+    else:
+        assert weights["30m"] >= weights["1m"]
+
+
+def test_gmv_raises_on_empty_covariance():
+    """Stress-weighted GMV should guard against empty covariance matrices."""
+
+    aggregator = StressWeightedGMV(tikhonov=1e-3, stress_weight=0.4)
+    with pytest.raises(ValueError, match="Covariance matrix must not be empty"):
+        aggregator({}, pd.DataFrame(), stress_level=1.0)
+
+
+def test_bundle_validation_missing_close_column(
+    bundle_without_close: MarketDataBundle, hurricane_config
+) -> None:
+    """Bundles lacking required price columns should fail validation."""
+
+    with pytest.raises(ValueError, match="Missing price columns"):
+        bundle_without_close.validate([tf.name for tf in hurricane_config.timeframes])
+
+
+def test_bundle_validation_negative_realised_vol(
+    bundle_with_negative_vol: MarketDataBundle, hurricane_config
+) -> None:
+    """Negative realised volatility entries must be rejected."""
+
+    with pytest.raises(ValueError, match="Realised volatility contains negatives"):
+        bundle_with_negative_vol.validate([tf.name for tf in hurricane_config.timeframes])
+
+
+def test_end_to_end_pipeline_output_matches_index(pipeline, dummy_bundle):
+    """Integration check verifying time-aligned diagnostic output."""
+
+    result = pipeline.run(dummy_bundle)
+    gating = result["diagnostics"]["gating"]
+    assert len(gating) == len(pipeline.config.timeframes)
+    weights = result["aggregate"]["weights"]
+    assert pytest.approx(sum(weights.values()), rel=1e-6) == 1.0


### PR DESCRIPTION
## Summary
- refactor the pipeline regression suite to use shared fixtures, add edge-case validation tests, and expand stress-weighted GMV assertions
- provide deterministic pytest fixtures for synthetic Hurricane SPY bundles and configurations
- add a GitHub Actions workflow that runs pytest with coverage and include pytest-cov in the requirements

## Testing
- pytest
- python -m hurricane_spy.scripts.run_pipeline

------
https://chatgpt.com/codex/tasks/task_e_68dd9cf2a958832788f0d9b070977aec